### PR TITLE
replace interface-name-prefix whith naming-convention rule

### DIFF
--- a/eslint/index.json
+++ b/eslint/index.json
@@ -174,10 +174,15 @@
     "@typescript-eslint/explicit-module-boundary-types": [
       "error"
     ],
-    "@typescript-eslint/interface-name-prefix": [
+    "@typescript-eslint/naming-convention": [
       "error",
       {
-        "prefixWithI": "always"
+        "selector": "interface",
+        "format": ["PascalCase"],
+        "custom": {
+          "regex": "^I[A-Z]",
+          "match": true
+        }
       }
     ],
     "@typescript-eslint/ban-types": [


### PR DESCRIPTION
`interface-name-prefix` rule deprecated and deleted.
https://github.com/typescript-eslint/typescript-eslint/pull/2002

should be replaced whith `naming-convention` rule.
https://github.com/typescript-eslint/typescript-eslint/blob/master/packages/eslint-plugin/docs/rules/naming-convention.md#enforce-that-interface-names-do-not-begin-with-an-i