### PR TITLE
eslint rules changes

### DIFF
--- a/eslint/index.json
+++ b/eslint/index.json
@@ -122,6 +122,7 @@
     "no-magic-numbers": [
       "error",
       {
+        "ignore": [-1, 0, 1],
         "ignoreArrayIndexes": true,
         "ignoreDefaultValues": true,
         "enforceConst": true
@@ -216,7 +217,8 @@
     {
         "files": ["*.test.ts", "*.test.tsx", "*.test.js", "*.test.jsx"],
         "rules": {
-            "no-magic-numbers": "off"
+            "no-magic-numbers": "off",
+            "react/jsx-props-no-spreading": "off"
         }
     }
   ]


### PR DESCRIPTION
- eslint: allow `-1`, `0` and `1` as magic numbers
- eslint: turn off `react/jsx-props-no-spreading` for test files