### PR TITLE
change rule import/order

### DIFF
--- a/eslint/index.json
+++ b/eslint/index.json
@@ -103,11 +103,19 @@
           "sibling",
           "index"
         ],
+        "pathGroups": [
+          {
+            "pattern": "react",
+            "group": "builtin",
+            "position": "before"
+          }
+        ],
+        "pathGroupsExcludedImportTypes": ["react"],
         "alphabetize": {
           "order": "asc",
           "caseInsensitive": true
         },
-        "newlines-between": "never"
+        "newlines-between": "ignore"
       }
     ],
     "newline-before-return": "error",


### PR DESCRIPTION
- `eslint`: rule `import/order` now asks to place `import ... from 'react'` on the top of the list with imports
- `eslint`: rule `import/order` now ignores newlines between import groups