### PR TITLE
eslint: fix typo in rule definition

### DIFF
--- a/eslint/index.json
+++ b/eslint/index.json
@@ -231,7 +231,7 @@
       "files": ["*.ts", "*.tsx"],
       "rules": {
         "no-duplicate-imports": "off",
-        "@typescipt-eslint/no-duplicate-imports": [
+        "@typescript-eslint/no-duplicate-imports": [
           "error", {
             "includeExports": true
           }


### PR DESCRIPTION
- `eslint`: fix typo in rule definition